### PR TITLE
CI

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: apt update
+      run: sudo apt-get update
     - name: add nasm
       run: sudo apt-get install -y nasm
     - name: Run tests

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -35,5 +35,4 @@ jobs:
       run: brew install nasm
     - name: Run tests
       run: cd nasm && make test_mains
-    - name: linkable binary
-      run: cd nasm && make bin && ./linkable_binary.out
+    # binary segfaults on gha macos (arm64)

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,37 @@
+name: c_binaries
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-linux:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add nasm
+      run: sudo apt-get install -y nasm
+    - name: Run tests
+      run: cd nasm && make test_mains
+    - name: linkable binary
+      run: cd nasm && make bin && ./linkable_binary.out
+  test-macos:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add nasm
+      run: brew install nasm
+    - name: Run tests
+      run: cd nasm && make test_mains
+    - name: linkable binary
+      run: cd nasm && make bin && ./linkable_binary.out

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: apt update
+      run: sudo apt-get update
     - name: add nasm
       run: sudo apt-get install -y nasm
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add nasm
+      run: sudo apt-get update -y; sudo apt-get install -y nasm
+    - name: add target
+      run: rustup target add x86_64-unknown-linux-gnu; rustup toolchain install --force-non-host nightly-x86_64-unknown-linux-gnu
+    - name: Run tests
+      run: cd use-from-rust && cargo test --target x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: add nasm
       run: sudo apt-get update -y; sudo apt-get install -y nasm
-    - name: add target
-      run: rustup target add x86_64-unknown-linux-gnu; rustup toolchain install --force-non-host nightly-x86_64-unknown-linux-gnu
     - name: Run tests
       run: cd use-from-rust && cargo test --target x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: add nasm
-      run: sudo apt-get update -y; sudo apt-get install -y nasm
+      run: sudo apt-get install -y nasm
     - name: Run tests
       run: cd use-from-rust && cargo test --target x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test-linux:
 
     runs-on: ubuntu-latest
 
@@ -21,3 +21,13 @@ jobs:
       run: sudo apt-get install -y nasm
     - name: Run tests
       run: cd use-from-rust && cargo test --target x86_64-unknown-linux-gnu
+  test-macos:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add nasm
+      run: brew install nasm
+    - name: Run tests
+      run: cd use-from-rust && cargo test --target x86_64-apple-darwin

--- a/nasm/Makefile
+++ b/nasm/Makefile
@@ -49,7 +49,7 @@ bonus: $(B_OBJ_FILES) $(OBJ_FILES)
 
 # run each c testing main file using their scripts
 test_mains: $(OBJ_FILES) $(B_OBJ_FILES)
-	@set -e; for src in $(SRC) $(B_SRC); do \
+	for src in $(SRC) $(B_SRC); do \
 		echo "Testing $$src"; \
 		(cd $$src && bash ./build_$$src.sh && ./test_$$src.out); \
 	done

--- a/nasm/Makefile
+++ b/nasm/Makefile
@@ -28,10 +28,10 @@ CC = clang
 all: $(NAME)
 bin:
 	$(MAKE) bonus
-	$(CC) $(ARCH) linkable_binary.c -L. -lasm -o linkable_binary.out 2>/dev/null
+	$(CC) -Wall -Wextra -Werror $(ARCH) linkable_binary.c -L. -lasm -o linkable_binary.out
 $(OBJ_DIR)/%.o: %.s | $(OBJ_DIR)
 	@mkdir -p $(dir $@)
-	nasm -f $(FORMAT) -o $@ $<
+	nasm -Wall -f $(FORMAT) -o $@ $<
 
 # Create all necessary directories
 $(OBJ_DIR):
@@ -63,7 +63,7 @@ clean:
 
 # Clean up compiled files and the library
 fclean: clean
-	rm -f $(NAME)
+	rm -f $(NAME) *.out
 	@set -e; for src in $(SRC) $(B_SRC); do \
 		rm -f $$src/test_$$src.out; \
 	done

--- a/use-from-rust/rust-toolchain.toml
+++ b/use-from-rust/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+version = "1.85.0"
+targets = [ "x86_64-apple-darwin", "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
### CI
- show linking from rust
- test main for each asm target
- test linkable binary on x86_64 ubuntu only (will produce weird behavior on macos gha runner)

### other
- trace warning about [section-crossing relocation](https://github.com/netwide-assembler/nasm/blob/888d9ab55012d25059da81fed6575ef3a004726f/asm/assemble.c#L328C38-L328C81)